### PR TITLE
Backendsrv: adds tests and refactors soft token path

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -213,12 +213,12 @@ export class BackendSrv implements BackendService {
               const firstAttempt = i === 0 && options.retry === 0;
 
               if (error.status === 401 && isLocalUrl(options.url) && firstAttempt && isSignedIn) {
-                if (error.data.message.includes('revoked')) {
-                  appEvents.emit(CoreEvents.showModalReact, {
+                if (error.data?.message?.includes('revoked')) {
+                  this.dependencies.appEvents.emit(CoreEvents.showModalReact, {
                     component: TokenRevokedModal,
                   });
 
-                  return of(null);
+                  return of({});
                 }
 
                 return from(this.loginPing()).pipe(

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -7,6 +7,7 @@ import { BackendSrv } from '../services/backend_srv';
 import { ContextSrv, User } from '../services/context_srv';
 import { describe, expect } from '../../../test/lib/common';
 import { BackendSrvRequest, FetchError } from '@grafana/runtime';
+import { TokenRevokedModal } from '../../features/users/TokenRevokedModal';
 
 const getTestContext = (overides?: object) => {
   const defaults = {
@@ -182,6 +183,32 @@ describe('backendSrv', () => {
             expect(appEventsMock.emit).toHaveBeenCalledTimes(1);
             expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertWarning, ['UnAuthorized', '']);
           });
+      });
+    });
+
+    describe('when making an unsuccessful call because of soft token revocation', () => {
+      it('then it should dispatch show Token Revoked modal event', async () => {
+        const url = '/api/dashboard/';
+        const { backendSrv, appEventsMock, logoutMock, expectRequestCallChain } = getTestContext({
+          ok: false,
+          status: 401,
+          statusText: 'UnAuthorized',
+          data: { message: 'Token revoked' },
+          url,
+        });
+
+        backendSrv.loginPing = jest.fn();
+
+        await backendSrv.request({ url, method: 'GET', retry: 0 }).catch((error) => {
+          expect(appEventsMock.emit).toHaveBeenCalledTimes(1);
+          expect(appEventsMock.emit).toHaveBeenCalledWith(
+            { name: 'show-modal-react' },
+            { component: TokenRevokedModal }
+          );
+          expect(backendSrv.loginPing).not.toHaveBeenCalled();
+          expect(logoutMock).not.toHaveBeenCalled();
+          expectRequestCallChain({ url, method: 'GET', retry: 0 });
+        });
       });
     });
 
@@ -388,6 +415,32 @@ describe('backendSrv', () => {
           expect(error.data).toEqual({ message: 'UnAuthorized' });
           expect(inspectorPacket).toBe(error);
           expect(backendSrv.loginPing).toHaveBeenCalledTimes(1);
+          expect(logoutMock).not.toHaveBeenCalled();
+          expectRequestCallChain({ url, method: 'GET', retry: 0 });
+        });
+      });
+    });
+
+    describe('when making an unsuccessful call because of soft token revocation', () => {
+      it('then it should dispatch show Token Revoked modal event', async () => {
+        const { backendSrv, logoutMock, appEventsMock, expectRequestCallChain } = getTestContext({
+          ok: false,
+          status: 401,
+          statusText: 'UnAuthorized',
+          data: { message: 'Token revoked' },
+        });
+
+        backendSrv.loginPing = jest.fn();
+
+        const url = '/api/dashboard/';
+
+        await backendSrv.datasourceRequest({ url, method: 'GET', retry: 0 }).catch((error) => {
+          expect(appEventsMock.emit).toHaveBeenCalledTimes(1);
+          expect(appEventsMock.emit).toHaveBeenCalledWith(
+            { name: 'show-modal-react' },
+            { component: TokenRevokedModal }
+          );
+          expect(backendSrv.loginPing).not.toHaveBeenCalled();
           expect(logoutMock).not.toHaveBeenCalled();
           expectRequestCallChain({ url, method: 'GET', retry: 0 });
         });


### PR DESCRIPTION
Something like this is a first step I think. I'd like to refactor it more splitting the toFailureStream into retryStream and softRevokeStream but that will have to wait until a later PR.